### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ on:
       - main
       - release/*
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ls1admin/docker-auto-cleaner/security/code-scanning/1](https://github.com/ls1admin/docker-auto-cleaner/security/code-scanning/1)

To fix the problem, we will explicitly define the `permissions` block for the workflow to adhere to the principle of least privilege. Since the workflow only checks out code and runs Go tests, it requires minimal permissions. We will set `contents: read` at the root of the workflow to limit the permissions of the `GITHUB_TOKEN` to read-only access to repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
